### PR TITLE
perf: unify parse routines of providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the `fujidana/spec-log` extension will be documented in t
 
 - Make file paths in a scan headers clickable links. The path is relative to the workspace, not to the log file.
 
+### Changed
+
+- Restructure the code to make it parse log files more efficiently.
+
 ## [1.4.3] -- 2025-06-07
 
 ### Changed

--- a/src/logProvider.ts
+++ b/src/logProvider.ts
@@ -48,7 +48,11 @@ const DATETIME_LINE_REGEXP = new RegExp(
 */
 const SCAN_LINE_REGEXP = /^(Scan\s+(\d+)\s{3}(\S.*?)\s{3})(?:(file\s*=\s*)(\S.*?)|\*\*NO DATA FILE\*\*)(?=\s{2})\s+(\S.*?)\s{2}user\s*=\s*(\S.*)$/;
 
-type ParsedData = { documentSymbols: vscode.DocumentSymbol[], documentLinks: vscode.DocumentLink[] };
+type ParsedData = {
+    foldingRanges: vscode.FoldingRange[],
+    documentSymbols: vscode.DocumentSymbol[],
+    documentLinks: vscode.DocumentLink[],
+};
 
 /**
  * Provider class
@@ -62,7 +66,7 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
         // this is also invoked after the user manually changed the language id
         const textDocumentDidOpenListener = (document: vscode.TextDocument) => {
             if (vscode.languages.match(LOG_SELECTOR, document)) {
-                this.parsedDataMap.set(document.uri.toString(), this.parseDocument(document));
+                this.parsedDataMap.set(document.uri.toString(), parseDocument(document));
             }
         };
 
@@ -70,7 +74,7 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
         const textDocumentDidChangeListener = (event: vscode.TextDocumentChangeEvent) => {
             const document = event.document;
             if (vscode.languages.match(LOG_SELECTOR, document)) {
-                this.parsedDataMap.set(document.uri.toString(), this.parseDocument(document));
+                this.parsedDataMap.set(document.uri.toString(), parseDocument(document));
             }
         };
 
@@ -85,11 +89,11 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
         // When the extension is activated by opening a log file, 
         for (const document of vscode.workspace.textDocuments) {
             if (vscode.languages.match(LOG_SELECTOR, document)) {
-                this.parsedDataMap.set(document.uri.toString(), this.parseDocument(document));
+                this.parsedDataMap.set(document.uri.toString(), parseDocument(document));
             }
         }
 
-        // register providers
+        // Register providers and event-callback functions.
         context.subscriptions.push(
             vscode.workspace.onDidOpenTextDocument(textDocumentDidOpenListener),
             vscode.workspace.onDidChangeTextDocument(textDocumentDidChangeListener),
@@ -106,70 +110,7 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
     public provideFoldingRanges(document: vscode.TextDocument, context: vscode.FoldingContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.FoldingRange[]> {
         if (token.isCancellationRequested) { return; }
 
-        const lineCount = document.lineCount;
-        const ranges: vscode.FoldingRange[] = [];
-        let welcomeLineIndex = -1;
-        let promptLineIndex = -1;
-        let updatingLineIndex = -1;
-        // let updatingType: 'number' | 'datetime' | undefined;
-
-        for (let index = 0; index < lineCount; index++) {
-            if (token.isCancellationRequested) { return; }
-
-            const text = document.lineAt(index).text;
-
-            // const isNumLine = NUMBER_LINE_REGEXP.test(text);
-            const isDateTimeLine = DATETIME_LINE_REGEXP.test(text);
-
-            if (isDateTimeLine) {
-                // if (isNumLine || isDateTimeLine) {
-                if (updatingLineIndex === -1) {
-                    updatingLineIndex = index;
-                    // updatingType = isNumLine ? 'number': 'datetime';
-                    // } else if (isNumLine && updatingType === 'datetime' || isDateTimeLine && updatingType === 'number') {
-                    //     if (updatingLineIndex < index - 2) {
-                    //         ranges.push(new vscode.FoldingRange(updatingLineIndex, index - 2));
-                    //     }
-                    //     updatingLineIndex = index;
-                    //     updatingType = isNumLine ? 'number': 'datetime';
-                }
-                continue;
-            } else if (updatingLineIndex !== -1) {
-                if (updatingLineIndex < index - 2) {
-                    ranges.push(new vscode.FoldingRange(updatingLineIndex, index - 2));
-                }
-                updatingLineIndex = -1;
-                // updatingType = undefined;
-            }
-
-            if (PROMPT_LINE_REGEXP.test(text)) {
-                if (promptLineIndex !== -1 && promptLineIndex < index - 1) {
-                    ranges.push(new vscode.FoldingRange(promptLineIndex, index - 1));
-                }
-                promptLineIndex = index;
-            } else if (WELCOME_LINE_REGEXP.test(text) && index > 0 && document.lineAt(index - 1).isEmptyOrWhitespace) {
-                if (promptLineIndex !== -1 && promptLineIndex < index - 2) {
-                    ranges.push(new vscode.FoldingRange(promptLineIndex, index - 2));
-                }
-                if (welcomeLineIndex !== -1 && welcomeLineIndex < index - 2) {
-                    ranges.push(new vscode.FoldingRange(welcomeLineIndex, index - 2));
-                }
-                promptLineIndex = index;
-                welcomeLineIndex = index - 1;
-            }
-        }
-
-        if (updatingLineIndex !== -1 && updatingLineIndex < lineCount - 2) {
-            ranges.push(new vscode.FoldingRange(updatingLineIndex, lineCount - 2));
-        }
-        if (promptLineIndex !== -1 && promptLineIndex < lineCount - 1) {
-            ranges.push(new vscode.FoldingRange(promptLineIndex, lineCount - 1));
-        }
-        if (welcomeLineIndex !== -1 && welcomeLineIndex < lineCount - 1) {
-            ranges.push(new vscode.FoldingRange(welcomeLineIndex, lineCount - 1));
-        }
-
-        return ranges;
+        return this.parsedDataMap.get(document.uri.toString())?.then(parsedData => parsedData.foldingRanges);
     }
 
     /**
@@ -178,10 +119,7 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
     public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
         if (token.isCancellationRequested) { return; }
 
-        const promisedData = this.parsedDataMap.get(document.uri.toString());
-        if (promisedData) {
-            return promisedData.then(parsedData => parsedData.documentSymbols);
-        }
+        return this.parsedDataMap.get(document.uri.toString())?.then(parsedData => parsedData.documentSymbols);
     }
 
     /**
@@ -190,95 +128,144 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
     public provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
         if (token.isCancellationRequested) { return; }
 
-        const promisedData = this.parsedDataMap.get(document.uri.toString());
-        if (promisedData) {
-            return promisedData.then(parsedData => parsedData.documentLinks);
-        }
+        return this.parsedDataMap.get(document.uri.toString())?.then(parsedData => parsedData.documentLinks);
     }
+}
 
-    /**
-     * Parse document.
-     */
-    async parseDocument(document: vscode.TextDocument): Promise<ParsedData> {
+/**
+ * Parse document.
+ */
+async function parseDocument(document: vscode.TextDocument): Promise<ParsedData> {
+    // if (token.isCancellationRequested) { return; }
+
+    const foldingRanges: vscode.FoldingRange[] = [];
+    const documentSymbols: vscode.DocumentSymbol[] = [];
+    const documentLinks: vscode.DocumentLink[] = [];
+
+    const lineCount = document.lineCount;
+    let counter = 0;
+    let prevWelcome: { lineNumber: number, symbol: vscode.DocumentSymbol } | undefined;
+    let prevPrompt: { lineNumber: number, symbol: vscode.DocumentSymbol } | undefined;
+    let umvStart = -1;
+
+    for (let lineNumber = 0; lineNumber < lineCount; lineNumber++) {
         // if (token.isCancellationRequested) { return; }
-        const lineCount = document.lineCount;
-        const welcomeSymbols: vscode.DocumentSymbol[] = [];
-        const documentLinks: vscode.DocumentLink[] = [];
-        let previousLine: vscode.TextLine | undefined;
-        let counter = 0;
-        let lastWelcomeSymbol: vscode.DocumentSymbol | undefined;
-        let lastPromptSymbol: vscode.DocumentSymbol | undefined;
 
-        for (let index = 0; index < lineCount; index++) {
-            // if (token.isCancellationRequested) { return; }
+        const currentLine = document.lineAt(lineNumber);
+        let matches: RegExpMatchArray | null;
 
-            const currentLine = document.lineAt(index);
-            let matches: RegExpMatchArray | null;
-            if ((matches = currentLine.text.match(PROMPT_LINE_REGEXP)) !== null) {
-                // update the range of previous prompt symbol
-                if (lastPromptSymbol && previousLine) {
-                    lastPromptSymbol.range = new vscode.Range(lastPromptSymbol.range.start, previousLine.range.end);
-                }
-                // create a new welcome symbol if not exist. This happens when the log file is deleted or moved during spec is running.
-                if (lastWelcomeSymbol === undefined) {
-                    const range = new vscode.Range(0, 0, 0, 0);
-                    lastWelcomeSymbol = new vscode.DocumentSymbol('session #0', '', vscode.SymbolKind.Enum, range, range);
-                    welcomeSymbols.push(lastWelcomeSymbol);
-                }
-                // create a new prompt symbol
-                lastPromptSymbol = new vscode.DocumentSymbol(matches[1], matches[2], vscode.SymbolKind.EnumMember, currentLine.range, currentLine.range);
-                lastWelcomeSymbol.children.push(lastPromptSymbol);
-            } else if ((matches = currentLine.text.match(WELCOME_LINE_REGEXP)) !== null && index > 0 && previousLine && previousLine.isEmptyOrWhitespace) {
-                // update the range of previous prompt symbol
-                if (lastPromptSymbol && previousLine && index > 1) {
-                    lastPromptSymbol.range = new vscode.Range(lastPromptSymbol.range.start, document.lineAt(index - 2).range.end);
-                }
-                // update the range of previous welcome symbol
-                if (lastWelcomeSymbol && previousLine && index > 1) {
-                    lastWelcomeSymbol.range = new vscode.Range(lastWelcomeSymbol.range.start, document.lineAt(index - 2).range.end);
-                }
-                // create a new welcome symbol
-                const range = new vscode.Range(previousLine.range.start, currentLine.range.end);
-                lastWelcomeSymbol = new vscode.DocumentSymbol(`session #${++counter}`, '', vscode.SymbolKind.Enum, range, range);
-                welcomeSymbols.push(lastWelcomeSymbol);
-                lastPromptSymbol = undefined;
-            } else if ((matches = currentLine.text.match(SCAN_LINE_REGEXP)) !== null) {
-                // make a link if a file path is found in a scan header line.
-                if (matches[5] && matches[5].length > 0) {
-                    const range = new vscode.Range(index, matches[1].length + matches[4].length, index, matches[1].length + matches[4].length + matches[5].length);
-                    let workspaceFolder: vscode.WorkspaceFolder | undefined;
-                    if (matches[5].startsWith('/')) {
-                        documentLinks.push(new vscode.DocumentLink(range, vscode.Uri.file(matches[5])));
-                    } else if ((workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)) !== undefined) {
-                        documentLinks.push(new vscode.DocumentLink(range, vscode.Uri.joinPath(workspaceFolder.uri, matches[5])));
-                    }
-                }
-
-                // comsume the continuous lines if they consists of numbers scan data
-                if (lastPromptSymbol && index + 4 < lineCount && document.lineAt(index + 2).isEmptyOrWhitespace && /\s*#/.test(document.lineAt(index + 3).text)) {
-                    const scanCommandStr = document.lineAt(index + 1).text;
-                    index += 4;
-                    while (index < lineCount && NUMBER_LINE_REGEXP.test(document.lineAt(index).text)) {
-                        index++;
-                    }
-                    index--;
-                    const range = new vscode.Range(currentLine.range.start, document.lineAt(index).range.end);
-                    lastPromptSymbol.children.push(new vscode.DocumentSymbol(`Scan ${matches[2]}`, scanCommandStr, vscode.SymbolKind.Number, range, currentLine.range));
-                }
+        // Make continuous lines consisting of number and date-time foldable.
+        if (DATETIME_LINE_REGEXP.test(currentLine.text)) {
+            if (umvStart === -1) {
+                umvStart = lineNumber;
             }
-            previousLine = currentLine;
+            continue;
+        } else if (umvStart !== -1) {
+            if (umvStart < lineNumber - 2) {
+                foldingRanges.push(new vscode.FoldingRange(umvStart, lineNumber - 2));
+            }
+            umvStart = -1;
         }
 
-        if (previousLine) {
-            // update the range of previous prompt symbol
-            if (lastPromptSymbol && previousLine) {
-                lastPromptSymbol.range = new vscode.Range(lastPromptSymbol.range.start, previousLine.range.end);
+        if ((matches = currentLine.text.match(PROMPT_LINE_REGEXP)) !== null) {
+            // In case the line is a prompt like `123.SPEC>`...
+            if (prevWelcome) {
+                // Make a block between "welcome" line and a line before the first prompt foldable.
+                if (prevWelcome.lineNumber >= 0 && prevWelcome.symbol.children.length === 0) {
+                    foldingRanges.push(new vscode.FoldingRange(prevWelcome.lineNumber + 1, lineNumber - 1));
+                }
+            } else {
+                // Create a dummy document symbol for welcome if it does not exist.
+                // This happens when the log file is deleted or moved during spec is running.
+                const range = new vscode.Range(0, 0, 0, 0);
+                const symbol = new vscode.DocumentSymbol('session #0', '', vscode.SymbolKind.Enum, range, range);
+                prevWelcome = { lineNumber: -1, symbol: symbol };
+                documentSymbols.push(symbol);
             }
-            // update the range of previous welcome symbol
-            if (lastWelcomeSymbol && previousLine) {
-                lastWelcomeSymbol.range = new vscode.Range(lastWelcomeSymbol.range.start, previousLine.range.end);
+
+            // Make the previous prompt block foldable.
+            if (prevPrompt && prevPrompt.lineNumber < lineNumber - 1) {
+                foldingRanges.push(new vscode.FoldingRange(prevPrompt.lineNumber, lineNumber - 1));
+                prevPrompt.symbol.range = new vscode.Range(prevPrompt.symbol.range.start, document.lineAt(lineNumber - 1).range.end);
+            }
+
+            // Create a new prompt symbol. The range is modified later.
+            const symbol = new vscode.DocumentSymbol(matches[1], matches[2], vscode.SymbolKind.EnumMember, currentLine.range, currentLine.range);
+            prevWelcome.symbol.children.push(symbol);
+            prevPrompt = { lineNumber: lineNumber, symbol: symbol };
+
+        } else if ((matches = currentLine.text.match(WELCOME_LINE_REGEXP)) !== null && lineNumber > 0 && document.lineAt(lineNumber - 1).isEmptyOrWhitespace) {
+            // In case the line is a welcome message like `Welcome to "spec" Release`,
+            // which means spec has just started.
+
+            // Update the range of previous prompt symbol.
+            if (prevPrompt && prevPrompt.lineNumber < lineNumber - 2) {
+                foldingRanges.push(new vscode.FoldingRange(prevPrompt.lineNumber, lineNumber - 2));
+                prevPrompt.symbol.range = new vscode.Range(prevPrompt.symbol.range.start, document.lineAt(lineNumber - 2).range.end);
+            }
+
+            // Update the range of previous welcome symbol.
+            if (prevWelcome && prevWelcome.lineNumber < lineNumber - 2) {
+                foldingRanges.push(new vscode.FoldingRange(prevWelcome.lineNumber, lineNumber - 2));
+                prevWelcome.symbol.range = new vscode.Range(prevWelcome.symbol.range.start, document.lineAt(lineNumber - 2).range.end);
+            }
+
+            // Create a new welcome symbol. The range is modified later.
+            const range = new vscode.Range(document.lineAt(lineNumber - 1).range.start, currentLine.range.end);
+            const symbol = new vscode.DocumentSymbol(`session #${++counter}`, '', vscode.SymbolKind.Enum, range, range);
+            documentSymbols.push(symbol);
+            prevWelcome = { lineNumber: lineNumber - 1, symbol: symbol };
+            prevPrompt = undefined;
+        } else if ((matches = currentLine.text.match(SCAN_LINE_REGEXP)) !== null) {
+            // Make a link if a file path is found in a scan header line.
+            if (matches[5] && matches[5].length > 0) {
+                const range = new vscode.Range(lineNumber, matches[1].length + matches[4].length, lineNumber, matches[1].length + matches[4].length + matches[5].length);
+                let workspaceFolder: vscode.WorkspaceFolder | undefined;
+                if (matches[5].startsWith('/')) {
+                    documentLinks.push(new vscode.DocumentLink(range, vscode.Uri.file(matches[5])));
+                } else if ((workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)) !== undefined) {
+                    documentLinks.push(new vscode.DocumentLink(range, vscode.Uri.joinPath(workspaceFolder.uri, matches[5])));
+                }
+            }
+
+            // Consume the continuous lines if they consists of numbers scan data.
+            if (prevPrompt && lineNumber + 4 < lineCount && document.lineAt(lineNumber + 2).isEmptyOrWhitespace && /\s*#/.test(document.lineAt(lineNumber + 3).text)) {
+                const scanCommandStr = document.lineAt(lineNumber + 1).text;
+                lineNumber += 4;
+                const scanStart = lineNumber;
+                while (lineNumber < lineCount && NUMBER_LINE_REGEXP.test(document.lineAt(lineNumber).text)) {
+                    lineNumber++;
+                }
+                lineNumber--;
+                if (scanStart < lineNumber - 2) {
+                    foldingRanges.push(new vscode.FoldingRange(scanStart, lineNumber - 1));
+                }
+
+                const range = new vscode.Range(currentLine.range.start, document.lineAt(lineNumber).range.end);
+                prevPrompt.symbol.children.push(new vscode.DocumentSymbol(`Scan ${matches[2]}`, scanCommandStr, vscode.SymbolKind.Number, range, currentLine.range));
             }
         }
-        return { documentSymbols: welcomeSymbols, documentLinks: documentLinks };
     }
+
+    if (umvStart !== -1 && umvStart < lineCount - 2) {
+        foldingRanges.push(new vscode.FoldingRange(umvStart, lineCount - 2));
+    }
+
+    const eofPosition = document.lineAt(lineCount - 1).range.end;
+
+    // Update the range of previous prompt symbol.
+    if (prevPrompt && prevPrompt.lineNumber < lineCount - 1) {
+        foldingRanges.push(new vscode.FoldingRange(prevPrompt.lineNumber, lineCount - 1));
+        prevPrompt.symbol.range = new vscode.Range(prevPrompt.symbol.range.start, eofPosition);
+    }
+
+    // Update the range of previous welcome symbol.
+    if (prevWelcome && prevWelcome.lineNumber < lineCount - 1) {
+        if (prevWelcome.lineNumber >= 0) {
+            foldingRanges.push(new vscode.FoldingRange(prevWelcome.lineNumber, lineCount - 1));
+        }
+        prevWelcome.symbol.range = new vscode.Range(prevWelcome.symbol.range.start, eofPosition);
+    }
+
+    return { foldingRanges, documentSymbols, documentLinks };
 }


### PR DESCRIPTION
The extension scans the text content of a log file twice when it is opened or updated, once for folding ranges (`provideFoldingRanges()`) and once for code navigation (`provideDocumentSymbols()`).

The parsing structure was recently modified a little for adopting the document link feature (#6) and in that code document symbols and links are parsed in the same scan. However, folding ranges are still scanned separately.

With this PR, the extension will parse a file just once to get both folding ranges and navigation symbols. While what the parser in this extension does is quite simple, a log file can be very long (a few MB and a few hundreds of thousands of lines, in my situation). I expect this will improve the performance in such a situation.