### PR TITLE
feat: add an editor action for folding/unfolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to the `fujidana/spec-log` extension will be documented in t
 
 ### Added
 
-- Make file paths in a scan headers clickable links. The path is relative to the workspace, not to the log file.
+- Make a file path in a scan header a clickable link. The relative path is resolved relative to the workspace, not to the log file.
+- Add editor action (button in editor toolbar) to fold/unfold. issue [#8](https://github.com/fujidana/vscode-spec-log/issues/8).
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,41 @@
 				"scopeName": "source.spec-log",
 				"path": "./syntaxes/specLog.tmLanguage.json"
 			}
-		]
+		],
+		"commands": [
+			{
+				"command": "spec-log.editor.foldLevel2",
+				"title": "Fold Prompts",
+				"icon": "$(folding-collapsed)",
+				"category": "spec-log"
+			},
+			{
+				"command": "spec-log.editor.unfoldAll",
+				"title": "Unfold All",
+				"icon": "$(folding-expanded)",
+				"category": "spec-log"
+			}
+		],
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "spec-log.editor.foldLevel2",
+					"when": "1 != 1"
+				},
+				{
+					"command": "spec-log.editor.unfoldAll",
+					"when": "1 != 1"
+				}
+			],
+			"editor/title": [
+				{
+					"command": "spec-log.editor.foldLevel2",
+					"alt": "spec-log.editor.unfoldAll",
+					"group": "navigation",
+					"when": "editorLangId == 'spec-log'"
+				}
+			]
+		}
 	},
 	"capabilities": {
 		"virtualWorkspaces": true,

--- a/src/logProvider.ts
+++ b/src/logProvider.ts
@@ -93,8 +93,18 @@ export class LogProvider implements vscode.FoldingRangeProvider, vscode.Document
             }
         }
 
+        const foldLevel2CommandHandler = (...args: any[]) => {
+            vscode.commands.executeCommand('editor.foldLevel2', ...args);
+        };
+
+        const unfoldAllCommandHandler = (...args: any[]) => {
+            vscode.commands.executeCommand('editor.unfoldAll', ...args);
+        };
+
         // Register providers and event-callback functions.
         context.subscriptions.push(
+            vscode.commands.registerCommand('spec-log.editor.foldLevel2', foldLevel2CommandHandler),
+            vscode.commands.registerCommand('spec-log.editor.unfoldAll', unfoldAllCommandHandler),
             vscode.workspace.onDidOpenTextDocument(textDocumentDidOpenListener),
             vscode.workspace.onDidChangeTextDocument(textDocumentDidChangeListener),
             vscode.workspace.onDidCloseTextDocument(textDocumentDidCloseListener),


### PR DESCRIPTION
Fixes #8

While `editor.foldLevel2` and `editor.unfoldAll` are built-in commands, directly defining them in package.json's "/contributes/commands" causes duplication in command palletes and also triggers activation of the extension even when one of the commands are executed to other file than`spec-log`.

To avoid activation, I created user-defined commands which just redirect to the built-in commands. To avoid duplication in command pallete, I set `1 != 1` (always falsy) to when-clause in "/contributes/menus/commandPalette".