### PR TITLE
bug: tlog graph preview not restored after relaunching VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `fujidana/spec-log` extension will be documented in t
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an issue where VS Code fails to restore previews after relaunched. Issue [[#21](https://github.com/fujidana/vscode-spec-log/issues/21)]
+
 ## [2.2.0] -- 2026-06-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 	},
 	"homepage": "https://github.com/fujidana/vscode-spec-log#readme",
 	"activationEvents": [
-		"onLanguage:spec-log"
+		"onLanguage:spec-log",
+		"onFileSystem:spec-log"
 	],
 	"main": "./dist/node/extension.js",
 	"browser": "./dist/web/extension.js",


### PR DESCRIPTION
Fixes #21